### PR TITLE
Add windows batch script to redirect among us networking

### DIFF
--- a/resources/redirect-to-localhost.bat
+++ b/resources/redirect-to-localhost.bat
@@ -1,0 +1,37 @@
+:: This list may not be complete, please send me more ip addresses accessed when this redirect is on
+:: You NEED Admin privileges to be able to run this file
+@echo off
+
+for /f "skip=3 tokens=4,*" %%a in ('
+    netsh interface ipv4 show interface
+') do (
+    echo +Found adapter %%b
+    if "%%a"=="connected" (
+        echo   +Enable dhcp/staticip-coexistence
+        :: Enable dhcp/staticip-coexistence, otherwise dhcp would be disabled
+        netsh interface ipv4 set interface "%%b" dhcpstaticipcoexistence=enabled
+        
+        :: Masters Lists Hardcoded
+        netsh interface ipv4 add address "%%b" 66.175.220.120  255.255.255.255
+        netsh interface ipv4 add address "%%b" 45.79.40.75     255.255.255.255
+        netsh interface ipv4 add address "%%b" 104.237.135.186 255.255.255.255
+        
+        :: America
+        netsh interface ipv4 add address "%%b" 198.58.115.57   255.255.255.255
+        netsh interface ipv4 add address "%%b" 198.58.99.71    255.255.255.255
+        netsh interface ipv4 add address "%%b" 50.116.1.42     255.255.255.255
+        netsh interface ipv4 add address "%%b" 45.79.5.6       255.255.255.255
+        netsh interface ipv4 add address "%%b" 45.79.67.124    255.255.255.255
+        
+        :: Asia
+        netsh interface ipv4 add address "%%b" 172.104.96.99   255.255.255.255
+        netsh interface ipv4 add address "%%b" 139.162.111.196 255.255.255.255
+        
+        :: Europe
+        netsh interface ipv4 add address "%%b" 139.162.220.199 255.255.255.255
+        netsh interface ipv4 add address "%%b" 172.105.251.35  255.255.255.255
+        netsh interface ipv4 add address "%%b" 172.105.251.170 255.255.255.255
+        netsh interface ipv4 add address "%%b" 172.105.249.25  255.255.255.255
+    )
+)
+echo Finished!

--- a/resources/remove-redirect-to-localhost.bat
+++ b/resources/remove-redirect-to-localhost.bat
@@ -1,0 +1,37 @@
+:: This list may not be complete, please send me more ip addresses accessed when this redirect is on
+:: You NEED Admin privileges to be able to run this file
+@echo off
+
+for /f "skip=3 tokens=4,*" %%a in ('
+    netsh interface ipv4 show interface
+') do (
+    echo +Found adapter %%b
+    if "%%a"=="connected" (
+        echo   +Disable dhcp/staticip-coexistence
+        :: Disable dhcp/staticip-coexistence again (maybe this is unnecessary or even undesired)
+        netsh interface ipv4 set interface "%%b" dhcpstaticipcoexistence=disabled
+        
+        :: Masters Lists Hardcoded
+        netsh interface ipv4 delete address "%%b" 66.175.220.120
+        netsh interface ipv4 delete address "%%b" 45.79.40.75
+        netsh interface ipv4 delete address "%%b" 104.237.135.186
+        
+        :: America
+        netsh interface ipv4 delete address "%%b" 198.58.115.575
+        netsh interface ipv4 delete address "%%b" 198.58.99.71
+        netsh interface ipv4 delete address "%%b" 50.116.1.42
+        netsh interface ipv4 delete address "%%b" 45.79.5.6
+        netsh interface ipv4 delete address "%%b" 45.79.67.124
+        
+        :: Asia
+        netsh interface ipv4 delete address "%%b" 172.104.96.99
+        netsh interface ipv4 delete address "%%b" 139.162.111.196
+        
+        :: Europe
+        netsh interface ipv4 delete address "%%b" 139.162.220.199
+        netsh interface ipv4 delete address "%%b" 172.105.251.35
+        netsh interface ipv4 delete address "%%b" 172.105.251.170
+        netsh interface ipv4 delete address "%%b" 172.105.249.25
+    )
+)
+echo Finished!

--- a/resources/remove-redirect-to-localhost.bat
+++ b/resources/remove-redirect-to-localhost.bat
@@ -17,7 +17,7 @@ for /f "skip=3 tokens=4,*" %%a in ('
         netsh interface ipv4 delete address "%%b" 104.237.135.186
         
         :: America
-        netsh interface ipv4 delete address "%%b" 198.58.115.575
+        netsh interface ipv4 delete address "%%b" 198.58.115.57
         netsh interface ipv4 delete address "%%b" 198.58.99.71
         netsh interface ipv4 delete address "%%b" 50.116.1.42
         netsh interface ipv4 delete address "%%b" 45.79.5.6


### PR DESCRIPTION
## Description

Currently there is only a script for redirecting networking to localhost for linux. For convenience I added a windows version of it.
The script enables dhcp/staticip-coexistence for all connected network adapters and then adds the static redirects.
The undo script undoes all of this, it is debatable if this script should even disable dhcp/staticip-coexistence again.

## Type of change

- [x] Added windows version of redirect-to-localhost.sh and its counterpart

## How Has This Been Tested?

Should be self explanatory.

**Test Configuration**:
- OS: Windows 10 Home Version 2004 Build 19041.630
- Java Version: OpenJDK 64-Bit Server VM (build 14.0.2+12-46, mixed mode, sharing)
